### PR TITLE
Change analyzer doc to remove duplication in help

### DIFF
--- a/maintidx.go
+++ b/maintidx.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-const doc = "maintidx measures the maintainability index of each function."
+const doc = "Measures the maintainability index of each function."
 
 var Analyzer = &analysis.Analyzer{
 	Name: "maintidx",


### PR DESCRIPTION
Before:
```
❯ go run cmd/maintidx/main.go -help maintidx
maintidx: maintidx measures the maintainability index of each function.
```

After:

```
❯ go run cmd/maintidx/main.go -help maintidx
maintidx: Measures the maintainability index of each function.
```