### PR TITLE
Update golang.org/x/tools to fix panic in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/yagipy/maintidx
 
 go 1.21
 
-require golang.org/x/tools v0.11.0
+require golang.org/x/tools v0.24.0
 
 require (
-	golang.org/x/mod v0.12.0 // indirect
-	golang.org/x/sys v0.11.0 // indirect
+	golang.org/x/mod v0.20.0 // indirect
+	golang.org/x/sync v0.8.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
-golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
-golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
-golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
-golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.11.0 h1:EMCa6U9S2LtZXLAMoWiR/R8dAQFRqbAitmbJ2UKhoi8=
-golang.org/x/tools v0.11.0/go.mod h1:anzJrxPjNtfgiYQYirP2CPGzGLxrH2u2QBhn6Bf3qY8=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=
+golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.24.0 h1:J1shsA93PJUEVaUSaay7UXAyE8aimq3GW0pjlolpa24=
+golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ=

--- a/testdata/go.mod
+++ b/testdata/go.mod
@@ -1,3 +1,0 @@
-module testdata
-
-go 1.21


### PR DESCRIPTION
This PR fixes panic in tests when Go 1.23 is used.

```
❯ go version
go version go1.23.4 darwin/arm64

❯ go test ./...
?       github.com/yagipy/maintidx/cmd/maintidx [no test files]
?       github.com/yagipy/maintidx/plugin       [no test files]
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104cd1834]

goroutine 93 [running]:
go/types.(*Checker).handleBailout(0x14000213880, 0x1400022fbb8)
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/check.go:404 +0x9c
panic({0x104deaac0?, 0x104fd06d0?})
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/runtime/panic.go:785 +0x124
go/types.(*StdSizes).Sizeof(0x0, {0x104e39228, 0x104fd3bc0})
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/sizes.go:229 +0x314
go/types.(*Config).sizeof(...)
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/sizes.go:334
go/types.representableConst.func1({0x104e39228?, 0x104fd3bc0?})
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/const.go:77 +0x90
go/types.representableConst({0x104e3a898, 0x104fc7e78}, 0x14000213880, 0x104fd3bc0, 0x1400022e998)
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/const.go:93 +0x134
go/types.(*Checker).representation(0x14000213880, 0x1400025e680, 0x104fd3bc0)
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/const.go:257 +0x68
go/types.(*Checker).implicitTypeAndValue(0x14000213880, 0x1400025e680, {0x104e39228, 0x104fd3bc0})
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/expr.go:377 +0x304
go/types.(*Checker).assignment(0x14000213880, 0x1400025e680, {0x104e39228, 0x104fd3bc0}, {0x104d4de23, 0xe})
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/assignments.go:70 +0x3ac
go/types.(*Checker).exprInternal(0x14000213880, 0x0, 0x1400025e680, {0x104e39c38, 0x14000011100}, {0x104e39278, 0x14000250150})
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/expr.go:1211 +0x1810
go/types.(*Checker).rawExpr(0x14000213880, 0x0, 0x1400025e680, {0x104e39c38?, 0x14000011100?}, {0x104e39278?, 0x14000250150?}, 0x0)
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/expr.go:981 +0x120
go/types.(*Checker).exprWithHint(0x14000213880, 0x1400025e680, {0x104e39c38, 0x14000011100}, {0x104e39278, 0x14000250150})
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/expr.go:1599 +0x64
go/types.(*Checker).indexedElts(0x14000213880, {0x1400025c008, 0x24, 0x14000257650?}, {0x104e39278, 0x14000250150}, 0xffffffffffffffff)
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/index.go:453 +0xcc
go/types.(*Checker).exprInternal(0x14000213880, 0x0, 0x1400025e600, {0x104e39c38, 0x14000011ec0}, {0x0, 0x0})
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/expr.go:1283 +0xbbc
go/types.(*Checker).rawExpr(0x14000213880, 0x0, 0x1400025e600, {0x104e39c38?, 0x14000011ec0?}, {0x0?, 0x0?}, 0x0)
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/expr.go:981 +0x120
go/types.(*Checker).expr(0x14000213880, 0x0?, 0x1400025e600, {0x104e39c38?, 0x14000011ec0?})
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/expr.go:1549 +0x38
go/types.(*Checker).varDecl(0x14000213880, 0x14000210f60, {0x140000522e0, 0x1, 0x1}, {0x0, 0x0}, {0x104e39c38, 0x14000011ec0})
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/decl.go:513 +0x140
go/types.(*Checker).objDecl(0x14000213880, {0x104e3ce78, 0x14000210f60}, 0x0)
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/decl.go:188 +0x7e0
go/types.(*Checker).packageObjects(0x14000213880)
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/resolver.go:714 +0x3f0
go/types.(*Checker).checkFiles(0x14000213880, {0x14000300500, 0x1, 0x1})
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/check.go:459 +0x190
go/types.(*Checker).Files(0x14000124000?, {0x14000300500?, 0x1400030c540?, 0x6?})
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/go/types/check.go:422 +0x80
golang.org/x/tools/go/packages.(*loader).loadPackage(0x14000124000, 0x140001872f0)
        /Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.11.0/go/packages/packages.go:1055 +0x858
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1()
        /Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.11.0/go/packages/packages.go:854 +0x178
sync.(*Once).doSlow(0x0?, 0x0?)
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/sync/once.go:76 +0xf8
sync.(*Once).Do(...)
        /opt/homebrew/Cellar/go/1.23.4/libexec/src/sync/once.go:67
golang.org/x/tools/go/packages.(*loader).loadRecursive(0x0?, 0x0?)
        /Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.11.0/go/packages/packages.go:842 +0x48
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1.1(0x0?)
        /Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.11.0/go/packages/packages.go:849 +0x30
created by golang.org/x/tools/go/packages.(*loader).loadRecursive.func1 in goroutine 90
        /Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.11.0/go/packages/packages.go:848 +0x84
FAIL    github.com/yagipy/maintidx      0.703s
ok      github.com/yagipy/maintidx/pkg/cyc      (cached) [no tests to run]
ok      github.com/yagipy/maintidx/pkg/halstvol (cached) [no tests to run]
FAIL
```